### PR TITLE
fix(servercluster): add omitempty to IDName.Name and make VPC optional

### DIFF
--- a/v2/types/servercluster/types.go
+++ b/v2/types/servercluster/types.go
@@ -20,7 +20,7 @@ import "encoding/json"
 
 type IDName struct {
 	ID   int    `json:"id"`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 type SrvClusterTemplateRef struct {
@@ -31,8 +31,8 @@ type SrvClusterTemplateRef struct {
 
 type Servers struct {
 	ID     int    `json:"id"`
-	Name   string `json:"name"`
-	Shared bool   `json:"shared"`
+	Name   string `json:"name,omitempty"`
+	Shared bool   `json:"shared,omitempty"`
 }
 
 type GatewayPrefix struct {
@@ -100,7 +100,7 @@ type ServerClusterW struct {
 	Name                    string       `json:"name"`
 	Admin                   IDName       `json:"admin"`
 	Site                    IDName       `json:"site"`
-	VPC                     IDName       `json:"vpc"`
+	VPC                     *IDName      `json:"vpc,omitempty"`
 	VPCList                 []VPCMapping `json:"vpcList,omitempty"`
 	SrvClusterTemplate      IDName       `json:"srvClusterTemplate"`
 	SrvClusterTemplateVLANs []VNetVLAN   `json:"-"`
@@ -121,7 +121,7 @@ func (s ServerClusterW) MarshalJSON() ([]byte, error) {
 		Name               string                `json:"name"`
 		Admin              IDName                `json:"admin"`
 		Site               IDName                `json:"site"`
-		VPC                IDName                `json:"vpc"`
+		VPC                *IDName               `json:"vpc,omitempty"`
 		VPCList            []VPCMapping          `json:"vpcList,omitempty"`
 		SrvClusterTemplate SrvClusterTemplateRef `json:"srvClusterTemplate"`
 		Tags               []string              `json:"tags"`


### PR DESCRIPTION
The IDName struct always serialized Name as "" when not set, causing "undefined (string) is required" errors from the Netris API. The API accepts ID-only references (matching the REST behavior where only the id field is sent).

- IDName.Name: omitempty — omit empty names from JSON
- Servers.Name/Shared: omitempty — same for server references
- ServerClusterW.VPC: pointer + omitempty — omit VPC entirely when not set, allowing the API to auto-create one per cluster